### PR TITLE
fix(senryu): prevent mention injection via user nicknames

### DIFF
--- a/main.go
+++ b/main.go
@@ -587,7 +587,7 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 					Content:   replyText,
 					Reference: m.Reference(),
 					AllowedMentions: &discordgo.MessageAllowedMentions{
-						Parse: []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeUsers},
+						Parse: []discordgo.AllowedMentionType{},
 					},
 					Flags: discordgo.MessageFlagsSuppressEmbeds,
 				}); err != nil {

--- a/main.go
+++ b/main.go
@@ -710,7 +710,7 @@ func handleYomeYomuna(m *discordgo.MessageCreate, s *discordgo.Session) bool {
 						senryus[2].Simogo,
 					}, " "), strings.Join(getWriters(senryus, m.GuildID, s), ", ")),
 				AllowedMentions: &discordgo.MessageAllowedMentions{
-					Parse: []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeUsers},
+					Parse: []discordgo.AllowedMentionType{},
 				},
 				Flags: discordgo.MessageFlagsSuppressEmbeds,
 			}); err != nil {
@@ -749,7 +749,7 @@ func handleYomeYomuna(m *discordgo.MessageCreate, s *discordgo.Session) bool {
 				Content:   reply,
 				Reference: m.Reference(),
 				AllowedMentions: &discordgo.MessageAllowedMentions{
-					Parse: []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeUsers},
+					Parse: []discordgo.AllowedMentionType{},
 				},
 				Flags: discordgo.MessageFlagsSuppressEmbeds,
 			}); err != nil {

--- a/main.go
+++ b/main.go
@@ -583,11 +583,14 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 				if spoiler {
 					replyText = fmt.Sprintf("川柳を検出しました！\n||「%s」||", h[0])
 				}
-				if _, err := s.ChannelMessageSendReply(
-					m.ChannelID,
-					replyText,
-					m.Reference(),
-				); err != nil {
+				if _, err := s.ChannelMessageSendComplex(m.ChannelID, &discordgo.MessageSend{
+					Content:   replyText,
+					Reference: m.Reference(),
+					AllowedMentions: &discordgo.MessageAllowedMentions{
+						Parse: []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeUsers},
+					},
+					Flags: discordgo.MessageFlagsSuppressEmbeds,
+				}); err != nil {
 					logger.Warn("Failed to send senryu reply", "error", err, "channel_id", m.ChannelID)
 					// 返信に失敗した場合、保存した川柳を削除して整合性を保つ
 					if delErr := service.DeleteSenryu(int(created.ID), m.GuildID); delErr != nil {
@@ -742,11 +745,14 @@ func handleYomeYomuna(m *discordgo.MessageCreate, s *discordgo.Session) bool {
 			} else {
 				reply = authorName + "が「" + senryu.Kamigo + " " + senryu.Nakasichi + " " + senryu.Simogo + "」って詠んだのが最後やぞ"
 			}
-			if _, err := s.ChannelMessageSendReply(
-				m.ChannelID,
-				reply,
-				m.Reference(),
-			); err != nil {
+			if _, err := s.ChannelMessageSendComplex(m.ChannelID, &discordgo.MessageSend{
+				Content:   reply,
+				Reference: m.Reference(),
+				AllowedMentions: &discordgo.MessageAllowedMentions{
+					Parse: []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeUsers},
+				},
+				Flags: discordgo.MessageFlagsSuppressEmbeds,
+			}); err != nil {
 				logger.Warn("Failed to send reply", "error", err, "channel_id", m.ChannelID)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -699,12 +699,18 @@ func handleYomeYomuna(m *discordgo.MessageCreate, s *discordgo.Session) bool {
 				logger.Warn("Failed to send message", "error", err, "channel_id", m.ChannelID)
 			}
 		} else {
-			if _, err := s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("ここで一句\n「%s」\n詠み手: %s",
-				strings.Join([]string{
-					senryus[0].Kamigo,
-					senryus[1].Nakasichi,
-					senryus[2].Simogo,
-				}, " "), strings.Join(getWriters(senryus, m.GuildID, s), ", "))); err != nil {
+			if _, err := s.ChannelMessageSendComplex(m.ChannelID, &discordgo.MessageSend{
+				Content: fmt.Sprintf("ここで一句\n「%s」\n詠み手: %s",
+					strings.Join([]string{
+						senryus[0].Kamigo,
+						senryus[1].Nakasichi,
+						senryus[2].Simogo,
+					}, " "), strings.Join(getWriters(senryus, m.GuildID, s), ", ")),
+				AllowedMentions: &discordgo.MessageAllowedMentions{
+					Parse: []discordgo.AllowedMentionType{discordgo.AllowedMentionTypeUsers},
+				},
+				Flags: discordgo.MessageFlagsSuppressEmbeds,
+			}); err != nil {
 				logger.Warn("Failed to send senryu message", "error", err, "channel_id", m.ChannelID)
 			}
 		}


### PR DESCRIPTION
## 問題

「詠め」コマンドで詠み手名を表示する際、ユーザーのニックネームをそのままメッセージに埋め込んでいるため、以下の攻撃が可能でした。

- ニックネームを `@everyone` や `@here` に設定 → ボットがサーバー全体へのメンションを送信してしまう
- ニックネームにURLを含める → ボットメッセージにURLプレビューが展開される

## 修正

`ChannelMessageSend` から `ChannelMessageSendComplex` に変更し、以下を設定:

- `AllowedMentions.Parse` をユーザーメンションのみに制限 (`@everyone` / `@here` / ロールメンションを無効化)
- `Flags: MessageFlagsSuppressEmbeds` でURLプレビューを抑制

## 再現手順

1. サーバーニックネームを `@everyone` に設定
2. 「詠め」を送信
3. ボットの返信で `@everyone` がメンションとして機能する