### PR TITLE
fix: Discord 障害時にギルドから抜けた扱いになりデータが削除される問題を修正

### DIFF
--- a/db/migrations/postgres/000005_create_unavailable_guilds.up.sql
+++ b/db/migrations/postgres/000005_create_unavailable_guilds.up.sql
@@ -1,0 +1,3 @@
+CREATE TABLE IF NOT EXISTS unavailable_guilds (
+    guild_id TEXT PRIMARY KEY
+);

--- a/db/migrations/sqlite3/000005_create_unavailable_guilds.up.sql
+++ b/db/migrations/sqlite3/000005_create_unavailable_guilds.up.sql
@@ -1,0 +1,3 @@
+CREATE TABLE IF NOT EXISTS unavailable_guilds (
+    guild_id TEXT PRIMARY KEY
+);

--- a/main.go
+++ b/main.go
@@ -149,6 +149,33 @@ var (
 	}
 )
 
+type guildEventTracker struct {
+	unavailableGuilds map[string]struct{}
+}
+
+func newGuildEventTracker() *guildEventTracker {
+	return &guildEventTracker{
+		unavailableGuilds: make(map[string]struct{}),
+	}
+}
+
+func registerGatewayHandlers(s *discordgo.Session) {
+	// DiscordGo otherwise runs typed handlers in independent goroutines, which can
+	// reorder guild availability transitions. Keep dispatch ordered and opt only
+	// the handlers that do substantial work back into asynchronous execution.
+	s.SyncEvents = true
+	s.AddHandler(func(s *discordgo.Session, m *discordgo.MessageCreate) {
+		go messageCreate(s, m)
+	})
+	s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+		go interactionCreate(s, i)
+	})
+	tracker := newGuildEventTracker()
+	s.AddHandler(tracker.guildCreate)
+	s.AddHandler(tracker.guildDelete)
+	s.AddHandler(onConnect)
+}
+
 func main() {
 	startTime = time.Now()
 
@@ -239,11 +266,7 @@ func main() {
 		s.ShardCount = shardCount
 		s.Identify.Intents = intents
 
-		s.AddHandler(messageCreate)
-		s.AddHandler(interactionCreate)
-		s.AddHandler(guildCreate)
-		s.AddHandler(guildDelete)
-		s.AddHandler(onConnect)
+		registerGatewayHandlers(s)
 
 		if err := s.Open(); err != nil {
 			logger.Error("Failed to open Discord connection", "error", err, "shard", i)
@@ -378,7 +401,7 @@ func onConnect(s *discordgo.Session, _ *discordgo.Connect) {
 	logger.Info("Gateway connected, caching guilds...", "shard", s.ShardID, "connected_shards", n, "expected_shards", expectedShards.Load())
 	botReady.Store(false)
 	// Reset debounce timer on new shard connection to prevent premature ready
-	if t := guildCacheTimer.Load(); t != nil {
+	if t := guildCacheTimer.Swap(nil); t != nil {
 		t.Stop()
 	}
 }
@@ -393,49 +416,99 @@ func countAllGuilds() int {
 	return total
 }
 
-func guildCreate(s *discordgo.Session, g *discordgo.GuildCreate) {
-	metrics.SetConnectedGuilds(countAllGuilds())
-	if !botReady.Load() {
-		logger.Debug("Guild cache", "name", g.Name, "id", g.ID)
-		// Register existing guilds so reconnect doesn't trigger welcome messages
-		commands.MarkGuildWelcomeSent(g.ID)
-		// Debounce: reset timer on each GUILD_CREATE during cache burst.
-		// When no more events arrive within 5s, mark as ready.
-		if t := guildCacheTimer.Load(); t != nil {
-			t.Stop()
+func resetGuildCacheTimer() {
+	// Debounce: reset timer on each GUILD_CREATE during cache burst.
+	// When no more events arrive within 5s, mark as ready.
+	t := time.AfterFunc(5*time.Second, func() {
+		if connectedShards.Load() < expectedShards.Load() {
+			// Not all shards connected yet; wait for remaining shards
+			logger.Info("Guild cache paused, waiting for remaining shards",
+				"guilds", countAllGuilds(),
+				"connected_shards", connectedShards.Load(),
+				"expected_shards", expectedShards.Load(),
+			)
+			return
 		}
-		t := time.AfterFunc(5*time.Second, func() {
-			if connectedShards.Load() < expectedShards.Load() {
-				// Not all shards connected yet; wait for remaining shards
-				logger.Info("Guild cache paused, waiting for remaining shards",
-					"guilds", countAllGuilds(),
-					"connected_shards", connectedShards.Load(),
-					"expected_shards", expectedShards.Load(),
-				)
-				return
-			}
-			total := countAllGuilds()
-			logger.Info("Guild cache complete, bot is ready", "guilds", total, "shards", expectedShards.Load())
-			metrics.SetConnectedGuilds(total)
-			botReady.Store(true)
-		})
-		guildCacheTimer.Store(t)
-		return
+		total := countAllGuilds()
+		logger.Info("Guild cache complete, bot is ready", "guilds", total, "shards", expectedShards.Load())
+		metrics.SetConnectedGuilds(total)
+		botReady.Store(true)
+	})
+	if previous := guildCacheTimer.Swap(t); previous != nil {
+		previous.Stop()
 	}
-	logger.Info("Joined guild", "name", g.Name, "id", g.ID)
-	if adminNotifier != nil {
-		adminNotifier.NotifyGuildJoin(g.Guild)
-	}
-	go commands.SendWelcomeMessage(s, g)
 }
 
-func guildDelete(s *discordgo.Session, g *discordgo.GuildDelete) {
+func cacheGuildCreate(g *discordgo.GuildCreate) {
+	logger.Debug("Guild cache", "name", g.Name, "id", g.ID)
+	// Register existing guilds so reconnect doesn't trigger welcome messages
+	commands.MarkGuildWelcomeSent(g.ID)
+	resetGuildCacheTimer()
+}
+
+func notifyGuildJoin(s *discordgo.Session, g *discordgo.GuildCreate) {
+	logger.Info("Joined guild", "name", g.Name, "id", g.ID)
+	notifier := adminNotifier
+	go func() {
+		if notifier != nil {
+			notifier.NotifyGuildJoin(g.Guild)
+		}
+		commands.SendWelcomeMessage(s, g)
+	}()
+}
+
+func (t *guildEventTracker) consumeRecovery(guildID string) bool {
+	if _, recovered := t.unavailableGuilds[guildID]; !recovered {
+		return false
+	}
+	delete(t.unavailableGuilds, guildID)
+	return true
+}
+
+func (t *guildEventTracker) guildCreate(s *discordgo.Session, g *discordgo.GuildCreate) {
+	metrics.SetConnectedGuilds(countAllGuilds())
+	if g.Unavailable {
+		logger.Warn("Guild unavailable", "id", g.ID)
+		if !botReady.Load() {
+			cacheGuildCreate(g)
+		}
+		return
+	}
+
+	if t.consumeRecovery(g.ID) {
+		logger.Info("Guild available again", "name", g.Name, "id", g.ID)
+		if !botReady.Load() {
+			cacheGuildCreate(g)
+		}
+		return
+	}
+
+	if !botReady.Load() {
+		cacheGuildCreate(g)
+		return
+	}
+
+	notifyGuildJoin(s, g)
+}
+
+func (t *guildEventTracker) prepareGuildDelete(g *discordgo.GuildDelete) bool {
+	if g.Unavailable {
+		t.unavailableGuilds[g.ID] = struct{}{}
+		logger.Warn("Guild temporarily unavailable", "id", g.ID)
+		return false
+	}
+
+	// A definitive delete supersedes any earlier temporary-unavailable event.
+	delete(t.unavailableGuilds, g.ID)
 	logger.Info("Left guild", "id", g.ID)
 	metrics.SetConnectedGuilds(countAllGuilds())
 
 	// Clear welcome-sent flag so re-invitation triggers a new welcome message
 	commands.ClearGuildWelcomeSent(g.ID)
+	return true
+}
 
+func cleanupGuildData(g *discordgo.GuildDelete, notifier *adminnotify.Manager, notify bool) {
 	// Clean up guild data
 	senryuCount, err := service.DeleteSenryuByServer(g.ID)
 	if err != nil {
@@ -457,9 +530,18 @@ func guildDelete(s *discordgo.Session, g *discordgo.GuildDelete) {
 		"channel_configs", channelConfigCount,
 	)
 
-	if botReady.Load() && adminNotifier != nil {
-		adminNotifier.NotifyGuildLeave(g, senryuCount, optOutCount)
+	if notify {
+		notifier.NotifyGuildLeave(g, senryuCount, optOutCount)
 	}
+}
+
+func (t *guildEventTracker) guildDelete(_ *discordgo.Session, g *discordgo.GuildDelete) {
+	if !t.prepareGuildDelete(g) {
+		return
+	}
+
+	notifier := adminNotifier
+	go cleanupGuildData(g, notifier, botReady.Load() && notifier != nil)
 }
 
 func interactionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {

--- a/main.go
+++ b/main.go
@@ -153,13 +153,17 @@ type guildEventTracker struct {
 	unavailableGuilds map[string]struct{}
 }
 
-func newGuildEventTracker() *guildEventTracker {
-	return &guildEventTracker{
-		unavailableGuilds: make(map[string]struct{}),
+func newGuildEventTracker(unavailableGuildIDs ...string) *guildEventTracker {
+	tracker := &guildEventTracker{
+		unavailableGuilds: make(map[string]struct{}, len(unavailableGuildIDs)),
 	}
+	for _, guildID := range unavailableGuildIDs {
+		tracker.unavailableGuilds[guildID] = struct{}{}
+	}
+	return tracker
 }
 
-func registerGatewayHandlers(s *discordgo.Session) {
+func registerGatewayHandlers(s *discordgo.Session, unavailableGuildIDs []string) {
 	// DiscordGo otherwise runs typed handlers in independent goroutines, which can
 	// reorder guild availability transitions. Keep dispatch ordered and opt only
 	// the handlers that do substantial work back into asynchronous execution.
@@ -170,7 +174,7 @@ func registerGatewayHandlers(s *discordgo.Session) {
 	s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		go interactionCreate(s, i)
 	})
-	tracker := newGuildEventTracker()
+	tracker := newGuildEventTracker(unavailableGuildIDs...)
 	s.AddHandler(tracker.guildCreate)
 	s.AddHandler(tracker.guildDelete)
 	s.AddHandler(onConnect)
@@ -213,6 +217,11 @@ func main() {
 	// Initialize database
 	if err := db.Init(); err != nil {
 		logger.Error("Failed to initialize database", "error", err)
+		os.Exit(1)
+	}
+	unavailableGuildIDs, err := service.ListUnavailableGuildIDs()
+	if err != nil {
+		logger.Error("Failed to load unavailable guilds", "error", err)
 		os.Exit(1)
 	}
 
@@ -266,7 +275,7 @@ func main() {
 		s.ShardCount = shardCount
 		s.Identify.Intents = intents
 
-		registerGatewayHandlers(s)
+		registerGatewayHandlers(s, unavailableGuildIDs)
 
 		if err := s.Open(); err != nil {
 			logger.Error("Failed to open Discord connection", "error", err, "shard", i)
@@ -462,6 +471,9 @@ func (t *guildEventTracker) consumeRecovery(guildID string) bool {
 		return false
 	}
 	delete(t.unavailableGuilds, guildID)
+	if err := service.ClearGuildUnavailable(guildID); err != nil {
+		logger.Error("Failed to clear unavailable guild", "error", err, "guild_id", guildID)
+	}
 	return true
 }
 
@@ -494,12 +506,18 @@ func (t *guildEventTracker) guildCreate(s *discordgo.Session, g *discordgo.Guild
 func (t *guildEventTracker) prepareGuildDelete(g *discordgo.GuildDelete) bool {
 	if g.Unavailable {
 		t.unavailableGuilds[g.ID] = struct{}{}
+		if err := service.MarkGuildUnavailable(g.ID); err != nil {
+			logger.Error("Failed to persist unavailable guild", "error", err, "guild_id", g.ID)
+		}
 		logger.Warn("Guild temporarily unavailable", "id", g.ID)
 		return false
 	}
 
 	// A definitive delete supersedes any earlier temporary-unavailable event.
 	delete(t.unavailableGuilds, g.ID)
+	if err := service.ClearGuildUnavailable(g.ID); err != nil {
+		logger.Error("Failed to clear unavailable guild", "error", err, "guild_id", g.ID)
+	}
 	logger.Info("Left guild", "id", g.ID)
 	metrics.SetConnectedGuilds(countAllGuilds())
 

--- a/main.go
+++ b/main.go
@@ -466,6 +466,13 @@ func notifyGuildJoin(s *discordgo.Session, g *discordgo.GuildCreate) {
 	}()
 }
 
+func (t *guildEventTracker) markUnavailable(guildID string) {
+	t.unavailableGuilds[guildID] = struct{}{}
+	if err := service.MarkGuildUnavailable(guildID); err != nil {
+		logger.Error("Failed to persist unavailable guild", "error", err, "guild_id", guildID)
+	}
+}
+
 func (t *guildEventTracker) consumeRecovery(guildID string) bool {
 	if _, recovered := t.unavailableGuilds[guildID]; !recovered {
 		return false
@@ -480,6 +487,7 @@ func (t *guildEventTracker) consumeRecovery(guildID string) bool {
 func (t *guildEventTracker) guildCreate(s *discordgo.Session, g *discordgo.GuildCreate) {
 	metrics.SetConnectedGuilds(countAllGuilds())
 	if g.Unavailable {
+		t.markUnavailable(g.ID)
 		logger.Warn("Guild unavailable", "id", g.ID)
 		if !botReady.Load() {
 			cacheGuildCreate(g)
@@ -505,10 +513,7 @@ func (t *guildEventTracker) guildCreate(s *discordgo.Session, g *discordgo.Guild
 
 func (t *guildEventTracker) prepareGuildDelete(g *discordgo.GuildDelete) bool {
 	if g.Unavailable {
-		t.unavailableGuilds[g.ID] = struct{}{}
-		if err := service.MarkGuildUnavailable(g.ID); err != nil {
-			logger.Error("Failed to persist unavailable guild", "error", err, "guild_id", g.ID)
-		}
+		t.markUnavailable(g.ID)
 		logger.Warn("Guild temporarily unavailable", "id", g.ID)
 		return false
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -18,7 +18,7 @@ func setupTestDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open test database: %v", err)
 	}
-	if err := db.DB.AutoMigrate(&model.MutedChannel{}, &model.GuildChannelTypeSetting{}).Error; err != nil {
+	if err := db.DB.AutoMigrate(&model.MutedChannel{}, &model.GuildChannelTypeSetting{}, &model.UnavailableGuild{}).Error; err != nil {
 		t.Fatalf("failed to migrate test database: %v", err)
 	}
 	t.Cleanup(func() {
@@ -29,43 +29,52 @@ func setupTestDB(t *testing.T) {
 func TestRegisterGatewayHandlers_Guildイベントを同期ディスパッチする(t *testing.T) {
 	session := &discordgo.Session{}
 
-	registerGatewayHandlers(session)
+	registerGatewayHandlers(session, nil)
 
 	if !session.SyncEvents {
 		t.Error("guild availability handlers require ordered synchronous dispatch")
 	}
 }
 
-func TestGuildCreate_UnavailableDelete後は復旧扱いする(t *testing.T) {
-	tracker := newGuildEventTracker()
+func TestGuildCreate_Bot再起動後もUnavailableDeleteからの復旧扱いにする(t *testing.T) {
+	setupTestDB(t)
 	const guildID = "temporarily-unavailable-guild"
+	beforeRestart := newGuildEventTracker()
 
-	if tracker.prepareGuildDelete(&discordgo.GuildDelete{
+	if beforeRestart.prepareGuildDelete(&discordgo.GuildDelete{
 		Guild: &discordgo.Guild{ID: guildID, Unavailable: true},
 	}) {
 		t.Fatal("temporary guild unavailability must not trigger data cleanup")
 	}
-	if _, tracked := tracker.unavailableGuilds[guildID]; !tracked {
-		t.Error("temporarily unavailable guild should be tracked until it recovers")
+
+	persistedGuildIDs, err := service.ListUnavailableGuildIDs()
+	if err != nil {
+		t.Fatalf("failed to reload unavailable guilds: %v", err)
 	}
-	if !tracker.consumeRecovery(guildID) {
-		t.Error("the next available event should be treated as recovery")
+	afterRestart := newGuildEventTracker(persistedGuildIDs...)
+	if !afterRestart.consumeRecovery(guildID) {
+		t.Error("the first available event after restart should be treated as recovery")
 	}
-	if tracker.consumeRecovery(guildID) {
+	if afterRestart.consumeRecovery(guildID) {
 		t.Error("the recovery marker should be consumed only once")
+	}
+	persistedGuildIDs, err = service.ListUnavailableGuildIDs()
+	if err != nil {
+		t.Fatalf("failed to reload unavailable guilds after recovery: %v", err)
+	}
+	if len(persistedGuildIDs) != 0 {
+		t.Errorf("the recovered guild marker should be removed: %v", persistedGuildIDs)
 	}
 }
 
 func TestGuildDelete_確定した脱退で一時切断状態を消去する(t *testing.T) {
-	tracker := newGuildEventTracker()
+	setupTestDB(t)
 	const guildID = "deleted-guild"
+	tracker := newGuildEventTracker()
 	if tracker.prepareGuildDelete(&discordgo.GuildDelete{
 		Guild: &discordgo.Guild{ID: guildID, Unavailable: true},
 	}) {
 		t.Fatal("temporary guild unavailability must not trigger data cleanup")
-	}
-	if _, tracked := tracker.unavailableGuilds[guildID]; !tracked {
-		t.Fatal("temporarily unavailable guild should be tracked")
 	}
 
 	if !tracker.prepareGuildDelete(&discordgo.GuildDelete{
@@ -76,6 +85,13 @@ func TestGuildDelete_確定した脱退で一時切断状態を消去する(t *t
 
 	if _, tracked := tracker.unavailableGuilds[guildID]; tracked {
 		t.Error("permanently deleted guild should no longer be tracked as unavailable")
+	}
+	persistedGuildIDs, err := service.ListUnavailableGuildIDs()
+	if err != nil {
+		t.Fatalf("failed to reload unavailable guilds: %v", err)
+	}
+	if len(persistedGuildIDs) != 0 {
+		t.Errorf("permanently deleted guild should no longer be persisted as unavailable: %v", persistedGuildIDs)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -26,6 +26,59 @@ func setupTestDB(t *testing.T) {
 	})
 }
 
+func TestRegisterGatewayHandlers_Guildイベントを同期ディスパッチする(t *testing.T) {
+	session := &discordgo.Session{}
+
+	registerGatewayHandlers(session)
+
+	if !session.SyncEvents {
+		t.Error("guild availability handlers require ordered synchronous dispatch")
+	}
+}
+
+func TestGuildCreate_UnavailableDelete後は復旧扱いする(t *testing.T) {
+	tracker := newGuildEventTracker()
+	const guildID = "temporarily-unavailable-guild"
+
+	if tracker.prepareGuildDelete(&discordgo.GuildDelete{
+		Guild: &discordgo.Guild{ID: guildID, Unavailable: true},
+	}) {
+		t.Fatal("temporary guild unavailability must not trigger data cleanup")
+	}
+	if _, tracked := tracker.unavailableGuilds[guildID]; !tracked {
+		t.Error("temporarily unavailable guild should be tracked until it recovers")
+	}
+	if !tracker.consumeRecovery(guildID) {
+		t.Error("the next available event should be treated as recovery")
+	}
+	if tracker.consumeRecovery(guildID) {
+		t.Error("the recovery marker should be consumed only once")
+	}
+}
+
+func TestGuildDelete_確定した脱退で一時切断状態を消去する(t *testing.T) {
+	tracker := newGuildEventTracker()
+	const guildID = "deleted-guild"
+	if tracker.prepareGuildDelete(&discordgo.GuildDelete{
+		Guild: &discordgo.Guild{ID: guildID, Unavailable: true},
+	}) {
+		t.Fatal("temporary guild unavailability must not trigger data cleanup")
+	}
+	if _, tracked := tracker.unavailableGuilds[guildID]; !tracked {
+		t.Fatal("temporarily unavailable guild should be tracked")
+	}
+
+	if !tracker.prepareGuildDelete(&discordgo.GuildDelete{
+		Guild: &discordgo.Guild{ID: guildID},
+	}) {
+		t.Fatal("definitive guild deletion should proceed to data cleanup")
+	}
+
+	if _, tracked := tracker.unavailableGuilds[guildID]; tracked {
+		t.Error("permanently deleted guild should no longer be tracked as unavailable")
+	}
+}
+
 func TestIsChannelTypeEnabled_デフォルト有効タイプ(t *testing.T) {
 	setupTestDB(t)
 

--- a/main_test.go
+++ b/main_test.go
@@ -67,6 +67,28 @@ func TestGuildCreate_Bot再起動後もUnavailableDeleteからの復旧扱いに
 	}
 }
 
+func TestGuildCreate_Unavailableイベント自体を復旧判定に使う(t *testing.T) {
+	setupTestDB(t)
+	const guildID = "unavailable-on-startup"
+	tracker := newGuildEventTracker()
+	previousBotReady := botReady.Load()
+	botReady.Store(true)
+	t.Cleanup(func() { botReady.Store(previousBotReady) })
+
+	tracker.guildCreate(nil, &discordgo.GuildCreate{
+		Guild: &discordgo.Guild{ID: guildID, Unavailable: true},
+	})
+
+	persistedGuildIDs, err := service.ListUnavailableGuildIDs()
+	if err != nil {
+		t.Fatalf("failed to reload unavailable guilds: %v", err)
+	}
+	afterRestart := newGuildEventTracker(persistedGuildIDs...)
+	if !afterRestart.consumeRecovery(guildID) {
+		t.Error("an unavailable GuildCreate should make the next available event a recovery")
+	}
+}
+
 func TestGuildDelete_確定した脱退で一時切断状態を消去する(t *testing.T) {
 	setupTestDB(t)
 	const guildID = "deleted-guild"

--- a/model/senryu.go
+++ b/model/senryu.go
@@ -40,3 +40,8 @@ type Metadata struct {
 	Key   string `gorm:"primaryKey;column:key"`
 	Value string `gorm:"column:value;not null"`
 }
+
+// UnavailableGuild records a guild hidden by a temporary Discord outage.
+type UnavailableGuild struct {
+	GuildID string `gorm:"primaryKey;column:guild_id"`
+}

--- a/service/guild_unavailability.go
+++ b/service/guild_unavailability.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/u16-io/FindSenryu4Discord/db"
+	"github.com/u16-io/FindSenryu4Discord/model"
+	"github.com/u16-io/FindSenryu4Discord/pkg/metrics"
+)
+
+// ListUnavailableGuildIDs returns guilds that were unavailable when the bot
+// last stopped. These IDs suppress recovery events from being treated as joins.
+func ListUnavailableGuildIDs() ([]string, error) {
+	metrics.RecordDatabaseOperation("list_unavailable_guilds")
+
+	var guilds []model.UnavailableGuild
+	if err := db.DB.Find(&guilds).Error; err != nil {
+		metrics.RecordError("database")
+		return nil, errors.Wrap(err, "failed to list unavailable guilds")
+	}
+
+	guildIDs := make([]string, 0, len(guilds))
+	for _, guild := range guilds {
+		guildIDs = append(guildIDs, guild.GuildID)
+	}
+	return guildIDs, nil
+}
+
+// MarkGuildUnavailable persists a temporary outage marker for a guild.
+func MarkGuildUnavailable(guildID string) error {
+	metrics.RecordDatabaseOperation("mark_guild_unavailable")
+
+	guild := model.UnavailableGuild{GuildID: guildID}
+	if err := db.DB.FirstOrCreate(&guild).Error; err != nil {
+		metrics.RecordError("database")
+		return errors.Wrap(err, "failed to mark guild unavailable")
+	}
+	return nil
+}
+
+// ClearGuildUnavailable removes a consumed or superseded outage marker.
+func ClearGuildUnavailable(guildID string) error {
+	metrics.RecordDatabaseOperation("clear_guild_unavailable")
+
+	if err := db.DB.Where("guild_id = ?", guildID).Delete(&model.UnavailableGuild{}).Error; err != nil {
+		metrics.RecordError("database")
+		return errors.Wrap(err, "failed to clear unavailable guild")
+	}
+	return nil
+}

--- a/service/guild_unavailability_test.go
+++ b/service/guild_unavailability_test.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/jinzhu/gorm"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/u16-io/FindSenryu4Discord/db"
+	"github.com/u16-io/FindSenryu4Discord/model"
+)
+
+func setupGuildUnavailabilityTestDB(t *testing.T) {
+	t.Helper()
+
+	var err error
+	db.DB, err = gorm.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+	if err := db.DB.AutoMigrate(&model.UnavailableGuild{}).Error; err != nil {
+		t.Fatalf("failed to migrate test database: %v", err)
+	}
+	t.Cleanup(func() { db.DB.Close() })
+}
+
+func TestGuildUnavailability(t *testing.T) {
+	setupGuildUnavailabilityTestDB(t)
+
+	if err := MarkGuildUnavailable("unavailable-guild"); err != nil {
+		t.Fatalf("failed to mark unavailable guild: %v", err)
+	}
+	if err := MarkGuildUnavailable("unavailable-guild"); err != nil {
+		t.Fatalf("marking a guild twice should be idempotent: %v", err)
+	}
+
+	guildIDs, err := ListUnavailableGuildIDs()
+	if err != nil {
+		t.Fatalf("failed to list unavailable guilds: %v", err)
+	}
+	if len(guildIDs) != 1 || guildIDs[0] != "unavailable-guild" {
+		t.Fatalf("unexpected unavailable guilds: %v", guildIDs)
+	}
+
+	if err := ClearGuildUnavailable("unavailable-guild"); err != nil {
+		t.Fatalf("failed to clear unavailable guild: %v", err)
+	}
+	guildIDs, err = ListUnavailableGuildIDs()
+	if err != nil {
+		t.Fatalf("failed to list unavailable guilds after clearing: %v", err)
+	}
+	if len(guildIDs) != 0 {
+		t.Fatalf("cleared unavailable guild should not remain: %v", guildIDs)
+	}
+}


### PR DESCRIPTION
Discord 側の障害でギルドが一時的に利用不能になると、`GuildDelete` イベントが `Unavailable=true` で送信されます。

従来はこれを Bot がギルドから退出した場合と同様に処理していたため、川柳、検出設定、チャンネル設定などのギルドデータが削除されていました。

## 変更内容

- `GuildDelete(Unavailable=true)` ではギルドデータを削除しないよう修正
- 一時的に利用不能となったギルド ID を記録
- ギルドが再び利用可能になった際の `GuildCreate` を新規参加ではなく復旧として処理
- 障害中に Bot が再起動しても復旧時に Join 通知を誤送信しないよう、障害マーカーを DB に永続化
- `GuildCreate(Unavailable=true)` から始まるケースにも対応
- 確定した退出では従来どおりギルドデータを削除
- Gateway のギルドイベントを順序どおり処理